### PR TITLE
Better coverage for property tests

### DIFF
--- a/wires-support/src/test/java/fr/cla/wires/support/oo/test/AbstractValueObject_PbtTest.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/oo/test/AbstractValueObject_PbtTest.java
@@ -3,7 +3,9 @@ package fr.cla.wires.support.oo.test;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import fr.cla.wires.support.oo.AbstractValueObject;
 import fr.cla.wires.support.pbt.*;
+import org.junit.Assume;
 import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -98,6 +100,8 @@ public class AbstractValueObject_PbtTest {
     public void equals_should_be_false_for_different_types(
         @RandomVoPair VoPair p
     ) {
+        Assume.assumeFalse(VoPairGenerator.current == AbstractValueObject.Equatability.IS_INSTANCE);
+
         if(!p.x.equals(p.y)) return;
 
         assertThat(

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/VoGenerator.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/VoGenerator.java
@@ -3,6 +3,7 @@ package fr.cla.wires.support.pbt;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import fr.cla.wires.support.functional.Indexed;
 import fr.cla.wires.support.oo.AbstractValueObject;
 import fr.cla.wires.support.pbt.examplevos.*;
 
@@ -15,17 +16,22 @@ public class VoGenerator extends Generator<VoSingleton> {
 
     @Override
     public VoSingleton generate(SourceOfRandomness rand, GenerationStatus status) {
-        return new VoSingleton(generate(rand));
+        return new VoSingleton(generate(rand, generateEquatability(rand)));
     }
 
-    static AbstractValueObject<?> generate(SourceOfRandomness rand) {
-        switch (rand.nextInt(6)) {
-            case 0: return VO1.random(rand);
-            case 1: return VO2.random(rand);
-            case 2: return VO1A.random(rand);
-            case 3: return VO1B.random(rand);
-            case 4: return VO2A.random(rand);
-            case 5: return VO2B.random(rand);
+    static AbstractValueObject.Equatability generateEquatability(SourceOfRandomness rand) {
+        return rand.choose(AbstractValueObject.Equatability.values());
+    }
+
+    static AbstractValueObject<?> generate(SourceOfRandomness rand, AbstractValueObject.Equatability e) {
+        switch (rand.nextInt(7)) {
+            case 0: return VO1.random(rand, e);
+            case 1: return VO2.random(rand, e);
+            case 2: return VO1A.random(rand, e);
+            case 3: return VO1B.random(rand, e);
+            case 4: return VO2A.random(rand, e);
+            case 5: return VO2B.random(rand, e);
+            case 6: return Indexed.index(rand.nextInt(), generate(rand, e));
             default: throw new AssertionError();
         }
     }

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/VoPairGenerator.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/VoPairGenerator.java
@@ -3,9 +3,12 @@ package fr.cla.wires.support.pbt;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import fr.cla.wires.support.oo.AbstractValueObject;
 
 //@formatter:off
 public class VoPairGenerator extends Generator<VoPair> {
+
+    public static AbstractValueObject.Equatability current = null;
 
     public VoPairGenerator() {
         super(VoPair.class);
@@ -13,9 +16,10 @@ public class VoPairGenerator extends Generator<VoPair> {
 
     @Override
     public VoPair generate(SourceOfRandomness rand, GenerationStatus status) {
+        current = VoGenerator.generateEquatability(rand);
         return new VoPair(
-            VoGenerator.generate(rand),
-            VoGenerator.generate(rand)
+            VoGenerator.generate(rand, current),
+            VoGenerator.generate(rand, current)
         );
     }
 

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/VoTripletGenerator.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/VoTripletGenerator.java
@@ -3,6 +3,7 @@ package fr.cla.wires.support.pbt;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import fr.cla.wires.support.oo.AbstractValueObject;
 
 //@formatter:off
 public class VoTripletGenerator extends Generator<VoTriplet> {
@@ -13,10 +14,11 @@ public class VoTripletGenerator extends Generator<VoTriplet> {
 
     @Override
     public VoTriplet generate(SourceOfRandomness rand, GenerationStatus status) {
+        AbstractValueObject.Equatability e = VoGenerator.generateEquatability(rand);
         return new VoTriplet(
-            VoGenerator.generate(rand),
-            VoGenerator.generate(rand),
-            VoGenerator.generate(rand)
+            VoGenerator.generate(rand, e),
+            VoGenerator.generate(rand, e),
+            VoGenerator.generate(rand, e)
         );
     }
 

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1.java
@@ -12,13 +12,13 @@ public class VO1 extends AbstractValueObject<VO1> {
 
     protected final Value x;
 
-    public VO1(Value x) {
-        super(VO1.class);
+    public VO1(Value x, Equatability e) {
+        super(VO1.class, e);
         this.x = x;
     }
 
-    public static VO1 random(SourceOfRandomness rand) {
-        return new VO1(Value.random(rand));
+    public static VO1 random(SourceOfRandomness rand, Equatability e) {
+        return new VO1(Value.random(rand), e);
     }
 
     @Override

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1.java
@@ -28,7 +28,7 @@ public class VO1 extends AbstractValueObject<VO1> {
 
     @Override
     protected boolean canEqual(AbstractValueObject<?> that) {
-        return that instanceof VO1;
+        return super.canEqual(that) && that instanceof VO1;
     }
 
 }

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1A.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1A.java
@@ -11,15 +11,16 @@ public class VO1A extends VO1 {
 
     private final Value y;
 
-    public VO1A(Value y, Value x) {
-        super(x);
+    public VO1A(Value y, Value x, Equatability e) {
+        super(x, e);
         this.y = y;
     }
 
-    public static VO1A random(SourceOfRandomness rand) {
+    public static VO1A random(SourceOfRandomness rand, Equatability e) {
         return new VO1A(
             Value.random(rand),
-            Value.random(rand)
+            Value.random(rand),
+            e
         );
     }
 

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1B.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO1B.java
@@ -11,15 +11,16 @@ public class VO1B extends VO1 {
 
     private final Value y;
 
-    public VO1B(Value y, Value x) {
-        super(x);
+    public VO1B(Value y, Value x, Equatability e) {
+        super(x, e);
         this.y = y;
     }
 
-    public static VO1B random(SourceOfRandomness rand) {
+    public static VO1B random(SourceOfRandomness rand, Equatability e) {
         return new VO1B(
             Value.random(rand),
-            Value.random(rand)
+            Value.random(rand),
+            e
         );
     }
 

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2.java
@@ -12,13 +12,13 @@ public class VO2 extends AbstractValueObject<VO2> {
 
     protected final Value x;
 
-    public VO2(Value x) {
-        super(VO2.class);
+    public VO2(Value x, Equatability e) {
+        super(VO2.class, e);
         this.x = x;
     }
 
-    public static VO2 random(SourceOfRandomness rand) {
-        return new VO2(Value.random(rand));
+    public static VO2 random(SourceOfRandomness rand, Equatability e) {
+        return new VO2(Value.random(rand), e);
     }
 
     @Override

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2.java
@@ -28,7 +28,7 @@ public class VO2 extends AbstractValueObject<VO2> {
 
     @Override
     protected boolean canEqual(AbstractValueObject<?> that) {
-        return that instanceof VO2;
+        return super.canEqual(that) && that instanceof VO2;
     }
 
 }

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2A.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2A.java
@@ -11,15 +11,16 @@ public class VO2A extends VO2 {
 
     private final Value y;
 
-    public VO2A(Value y, Value x) {
-        super(x);
+    public VO2A(Value y, Value x, Equatability e) {
+        super(x, e);
         this.y = y;
     }
 
-    public static VO2A random(SourceOfRandomness rand) {
+    public static VO2A random(SourceOfRandomness rand, Equatability e) {
         return new VO2A(
             Value.random(rand),
-            Value.random(rand)
+            Value.random(rand),
+            e
         );
     }
 

--- a/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2B.java
+++ b/wires-support/src/test/java/fr/cla/wires/support/pbt/examplevos/VO2B.java
@@ -11,15 +11,16 @@ public class VO2B extends VO2 {
 
     private final Value y;
 
-    public VO2B(Value y, Value x) {
-        super(x);
+    public VO2B(Value y, Value x, Equatability e) {
+        super(x, e);
         this.y = y;
     }
 
-    public static VO2B random(SourceOfRandomness rand) {
+    public static VO2B random(SourceOfRandomness rand, Equatability e) {
         return new VO2B(
             Value.random(rand),
-            Value.random(rand)
+            Value.random(rand),
+            e
         );
     }
 


### PR DESCRIPTION
This change improves the coverage of some property tests by improving the generator:
* The generator of `examplevos` objects now picks a type of equatability at random
* The property tests now cover all implementations of method `areEquatable` in the enum `AbstractValueObject.Equatability`
* The property tests now cover method `canEqual` in class `AbstractValueObject`
* The property tests now cover method `equalityCriteria` in class `Indexed`